### PR TITLE
Feat/#6 액세스 토큰 재발급 기능

### DIFF
--- a/src/main/java/com/groommoa/aether_back_spring/global/auth/controller/AuthController.java
+++ b/src/main/java/com/groommoa/aether_back_spring/global/auth/controller/AuthController.java
@@ -2,19 +2,23 @@ package com.groommoa.aether_back_spring.global.auth.controller;
 
 import com.groommoa.aether_back_spring.global.auth.service.TokenService;
 import com.groommoa.aether_back_spring.global.common.constants.HttpStatus;
+import com.groommoa.aether_back_spring.global.common.constants.TokenKey;
 import com.groommoa.aether_back_spring.global.common.response.CommonResponse;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.core.userdetails.UserDetails;
-import org.springframework.web.bind.annotation.DeleteMapping;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.util.StringUtils;
+import org.springframework.web.bind.annotation.*;
 
 import java.util.HashMap;
 import java.util.Map;
 
+import static org.springframework.http.HttpHeaders.AUTHORIZATION;
+
+@RequestMapping("/auth")
 @RequiredArgsConstructor
 @RestController
 public class AuthController {
@@ -26,7 +30,7 @@ public class AuthController {
      * @param accessToken 서버에서 발급된 JWT access token
      * @return 로그인 성공 응답과 JWT access token
      */
-    @GetMapping("/auth/success")
+    @GetMapping("/success")
     public ResponseEntity<CommonResponse> loginSuccess(@RequestParam String accessToken) {
         Map<String, Object> result = new HashMap<>();
         result.put("accessToken", accessToken);
@@ -42,7 +46,7 @@ public class AuthController {
      * @param userDetails 현재 로그인한 사용자의 정보 (Spring Security 제공)
      * @return 로그아웃 성공 응답
      */
-    @DeleteMapping("/auth/logout")
+    @DeleteMapping("/logout")
     public ResponseEntity<CommonResponse> logout(@AuthenticationPrincipal UserDetails userDetails) {
         // 사용자 계정과 연관된 refresh token 삭제
         tokenService.deleteRefreshToken(userDetails.getUsername());
@@ -51,5 +55,30 @@ public class AuthController {
         CommonResponse response = new CommonResponse(
                 HttpStatus.OK, "로그아웃에 성공했습니다.", null);
         return ResponseEntity.ok(response);
+    }
+
+    @GetMapping("/reissue")
+    public ResponseEntity<CommonResponse> reissueAccessToken(HttpServletResponse response) {
+        String newAccessToken = response.getHeader(AUTHORIZATION);
+
+        // 접두사 제거
+        if (StringUtils.hasText(newAccessToken) && newAccessToken.startsWith(TokenKey.TOKEN_PREFIX)) {
+            newAccessToken = newAccessToken.substring(TokenKey.TOKEN_PREFIX.length());
+        } else {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
+                    .body(new CommonResponse(HttpStatus.UNAUTHORIZED, "access token 재발급에 실패했습니다.", null));
+        }
+
+        Map<String, Object> result = new HashMap<>();
+        result.put("accessToken", newAccessToken);
+
+        return ResponseEntity.ok(new CommonResponse(
+                HttpStatus.OK, "access token 재발급에 성공했습니다.", result));
+    }
+
+    @GetMapping("/test")
+    public ResponseEntity<CommonResponse> test() {
+        return ResponseEntity.ok(new CommonResponse(
+                HttpStatus.OK, "auth 테스트 요청 입니다.", null));
     }
 }

--- a/src/main/java/com/groommoa/aether_back_spring/global/auth/controller/AuthController.java
+++ b/src/main/java/com/groommoa/aether_back_spring/global/auth/controller/AuthController.java
@@ -57,6 +57,11 @@ public class AuthController {
         return ResponseEntity.ok(response);
     }
 
+    /**
+     * accessToken을 재발급함
+     * @param response HTTP 응답 객체
+     * @return 재발급된 accessToken을 포함한 응답
+     */
     @GetMapping("/reissue")
     public ResponseEntity<CommonResponse> reissueAccessToken(HttpServletResponse response) {
         String newAccessToken = response.getHeader(AUTHORIZATION);
@@ -76,6 +81,11 @@ public class AuthController {
                 HttpStatus.OK, "access token 재발급에 성공했습니다.", result));
     }
 
+    /**
+     * 테스트용 엔드포인트
+     *
+     * @return 인증 테스트 성공 응답을 반환합니다.
+     */
     @GetMapping("/test")
     public ResponseEntity<CommonResponse> test() {
         return ResponseEntity.ok(new CommonResponse(

--- a/src/main/java/com/groommoa/aether_back_spring/global/auth/security/TokenProvider.java
+++ b/src/main/java/com/groommoa/aether_back_spring/global/auth/security/TokenProvider.java
@@ -11,6 +11,7 @@ import io.jsonwebtoken.security.Keys;
 import io.jsonwebtoken.security.SecurityException;
 import jakarta.annotation.PostConstruct;
 import lombok.RequiredArgsConstructor;
+import org.reactivestreams.Publisher;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;

--- a/src/main/java/com/groommoa/aether_back_spring/global/common/constants/HttpStatus.java
+++ b/src/main/java/com/groommoa/aether_back_spring/global/common/constants/HttpStatus.java
@@ -3,4 +3,5 @@ package com.groommoa.aether_back_spring.global.common.constants;
 public final class HttpStatus {
 
     public static final int OK = 200;
+    public static final int UNAUTHORIZED = 401;
 }

--- a/src/test/java/com/groommoa/aether_back_spring/global/auth/controller/AuthControllerTest.java
+++ b/src/test/java/com/groommoa/aether_back_spring/global/auth/controller/AuthControllerTest.java
@@ -2,24 +2,36 @@ package com.groommoa.aether_back_spring.global.auth.controller;
 
 import com.groommoa.aether_back_spring.global.auth.security.TokenProvider;
 import com.groommoa.aether_back_spring.global.auth.service.TokenService;
+import com.groommoa.aether_back_spring.global.common.constants.TokenKey;
+import jakarta.servlet.http.HttpServletResponse;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.web.context.WebApplicationContext;
 
+import java.util.Collections;
+
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.*;
+import static org.springframework.http.HttpHeaders.AUTHORIZATION;
+import static org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers.springSecurity;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
-@WebMvcTest(AuthController.class)
+@SpringBootTest
+@AutoConfigureMockMvc
 public class AuthControllerTest {
 
     @MockitoBean
@@ -38,7 +50,30 @@ public class AuthControllerTest {
     void setUp() {
         mockMvc = MockMvcBuilders
                 .webAppContextSetup(webApplicationContext)
+                .apply(springSecurity())
                 .build();
+    }
+
+    @Test
+    @DisplayName("인증 - 유효한 accessToken으로 인증 성공")
+    void shouldAuthenticateWithValidAccessToken() throws Exception {
+        // given: 유효한 accessToken
+        String validAccessToken = "validAccessToken";
+
+        // Mock 설정: accessToken이 유효한 경우
+        when(tokenProvider.validateToken(validAccessToken)).thenReturn(true);
+
+        Authentication mockAuthentication = new UsernamePasswordAuthenticationToken("user", "", Collections.emptyList());
+        when(tokenProvider.getAuthentication(validAccessToken)).thenReturn(mockAuthentication);
+
+        // when: 유효한 토큰을 Authorization 헤더에 넣고 요청
+        ResultActions result = mockMvc.perform(get("/auth/test")
+                .header(AUTHORIZATION, TokenKey.TOKEN_PREFIX + validAccessToken));
+
+        // then: 인증 성공하여 200 OK 응답을 받음
+        result.andExpect(status().isOk())
+                .andDo(print());
+
     }
 
     @Test
@@ -49,6 +84,27 @@ public class AuthControllerTest {
 
         mockMvc.perform(delete("/auth/logout"))
                 .andExpect(status().isOk())
+                .andDo(print());
+    }
+
+    @Test
+    @WithMockUser(username = "user")
+    @DisplayName("accessToken 갱신 - 새로운 accessToken 반환")
+    void reissueAccessToken() throws Exception {
+        // given: 만료된 accessToken과 새로 재발급될 accessToken 설정
+        String expiredAccessToken = "expiredAccessToken";
+        String newAccessToken = "newAccessToken";
+
+        // Mock 설정: 만료된 토큰은 유효하지 않음
+        when(tokenProvider.validateToken(expiredAccessToken)).thenReturn(false);
+        when(tokenProvider.reissueAccessToken(expiredAccessToken)).thenReturn(newAccessToken);
+        when(tokenProvider.getAuthentication(newAccessToken))
+                .thenReturn(new UsernamePasswordAuthenticationToken("user", "", Collections.emptyList())); // ✅ 인증 객체 Mocking
+
+        ResultActions result = mockMvc.perform(get("/auth/reissue")
+                .header(AUTHORIZATION, TokenKey.TOKEN_PREFIX + expiredAccessToken));
+
+        result.andExpect(status().isOk())
                 .andDo(print());
     }
 }


### PR DESCRIPTION
## Description
액세스 토큰이 만료된 경우, 리프레시 토큰을 이용하여 새로운 액세스 토큰을 발급하는 기능을 구현했습니다.
## Changes

- 리프레시 토큰을 통한 액세스 토큰 재발급 엔드포인트 구현

## API Specification

### 1. 액세스 토큰 재발급 API
- **Method**: POST
- **Endpoint**: /auth/reissue
- **Request Headers**:
 `{
  "Authorization": "Bearer <ACCESS_TOKEN>"
}`
- **Request Body**: `None`
- **Response - 200 OK**:
`{"code":200,"message":"access token 재발급에 성공했습니다.","result":{"accessToken":"{newAccessToken}"}}`
- **Response - 401 Unauthorized**:
`{"code":401,"message":"access token 재발급에 실패했습니다.","result":null}`

## Testing
- 기존 액세스 토큰이 만료된 경우 정상적으로 재발급되는지 테스트 완료
- 유효하지 않은 액세스 토큰 전달 시 적절한 에러 반환 확인