### PR TITLE
Feat/#13 유저 토큰 정보 저장 방식 변경

### DIFF
--- a/src/main/java/com/groommoa/aether_back_spring/global/auth/controller/AuthController.java
+++ b/src/main/java/com/groommoa/aether_back_spring/global/auth/controller/AuthController.java
@@ -1,5 +1,6 @@
 package com.groommoa.aether_back_spring.global.auth.controller;
 
+import com.groommoa.aether_back_spring.global.auth.model.PrincipalDetails;
 import com.groommoa.aether_back_spring.global.auth.service.TokenService;
 import com.groommoa.aether_back_spring.global.common.constants.HttpStatus;
 import com.groommoa.aether_back_spring.global.common.constants.TokenKey;
@@ -48,12 +49,17 @@ public class AuthController {
      */
     @DeleteMapping("/logout")
     public ResponseEntity<CommonResponse> logout(@AuthenticationPrincipal UserDetails userDetails) {
+
         // 사용자 계정과 연관된 refresh token 삭제
-        tokenService.deleteRefreshToken(userDetails.getUsername());
+        String userId = userDetails.getUsername();
+        tokenService.deleteRefreshToken(userId);
 
         // 로그아웃 성공 응답 객체 생성
+        Map<String, Object> result = new HashMap<>();
+        result.put("requestedId", userId);
+
         CommonResponse response = new CommonResponse(
-                HttpStatus.OK, "로그아웃에 성공했습니다.", null);
+                HttpStatus.OK, "로그아웃에 성공했습니다.", result);
         return ResponseEntity.ok(response);
     }
 

--- a/src/main/java/com/groommoa/aether_back_spring/global/auth/handler/OAuth2SuccessHandler.java
+++ b/src/main/java/com/groommoa/aether_back_spring/global/auth/handler/OAuth2SuccessHandler.java
@@ -1,10 +1,12 @@
 package com.groommoa.aether_back_spring.global.auth.handler;
 
+import com.groommoa.aether_back_spring.global.auth.model.PrincipalDetails;
 import com.groommoa.aether_back_spring.global.auth.security.TokenProvider;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.Authentication;
+import org.springframework.security.oauth2.core.user.OAuth2User;
 import org.springframework.security.web.authentication.AuthenticationSuccessHandler;
 import org.springframework.stereotype.Component;
 import org.springframework.web.util.UriComponentsBuilder;
@@ -35,8 +37,10 @@ public class OAuth2SuccessHandler implements AuthenticationSuccessHandler {
     public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response,
                                         Authentication authentication) throws IOException {
         // accessToken, refreshToken 발급
-        String accessToken = tokenProvider.generateAccessToken(authentication);
-        tokenProvider.generateRefreshToken(authentication, accessToken);
+        PrincipalDetails principalDetails = (PrincipalDetails) authentication.getPrincipal();
+
+        String accessToken = tokenProvider.generateAccessToken(principalDetails);
+        tokenProvider.generateRefreshToken(principalDetails, accessToken);
 
         // 클라이언트를 인증 성공 페이지로 리다이렉트
         String redirectUrl = UriComponentsBuilder.fromUriString(URI)

--- a/src/main/java/com/groommoa/aether_back_spring/global/auth/model/PrincipalDetails.java
+++ b/src/main/java/com/groommoa/aether_back_spring/global/auth/model/PrincipalDetails.java
@@ -65,6 +65,6 @@ public record PrincipalDetails(
 
     @Override
     public String getUsername() {
-        return member.getEmail();
+        return member.getId();
     }
 }

--- a/src/main/java/com/groommoa/aether_back_spring/global/auth/security/TokenProvider.java
+++ b/src/main/java/com/groommoa/aether_back_spring/global/auth/security/TokenProvider.java
@@ -18,6 +18,7 @@ import org.springframework.security.authentication.UsernamePasswordAuthenticatio
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.userdetails.User;
+import org.springframework.security.oauth2.core.user.OAuth2User;
 import org.springframework.stereotype.Component;
 import org.springframework.util.StringUtils;
 
@@ -55,36 +56,35 @@ public class TokenProvider {
     /**
      * AccessToken 생성
      *
-     * @param authentication 인증 객체
+     * @param principalDetails 인증된 유저 정보 객체
      * @return 생성된 AccessToken
      */
-    public String generateAccessToken(Authentication authentication) {
-        return generateToken(authentication, ACCESS_TOKEN_EXPIRE_TIME);
+    public String generateAccessToken(PrincipalDetails principalDetails) {
+        return generateToken(principalDetails, ACCESS_TOKEN_EXPIRE_TIME);
     }
 
     /**
      * RefreshToken을 생성하고 Redis에 저장
      *
-     * @param authentication 인증 객체
+     * @param principalDetails 인증된 유저 정보 객체
      * @param accessToken    발급된 AccessToken
      */
-    public void generateRefreshToken(Authentication authentication, String accessToken) {
-        String refreshToken = generateToken(authentication, REFRESH_TOKEN_EXPIRE_TIME);
-        tokenService.saveOrUpdate(authentication.getName(), refreshToken, accessToken);
+    public void generateRefreshToken(PrincipalDetails principalDetails, String accessToken) {
+        String refreshToken = generateToken(principalDetails, REFRESH_TOKEN_EXPIRE_TIME);
+        tokenService.saveOrUpdate(principalDetails.getUsername(), refreshToken, accessToken);
     }
 
     /**
      * JWT 토큰을 생성하는 내부 메서드
      *
-     * @param authentication 인증 객체
+     * @param principalDetails 인증된 유저 정보 객체
      * @param expireTime     토큰 만료 시간
      * @return 생성된 JWT 토큰
      */
-    private String generateToken(Authentication authentication, long expireTime) {
+    private String generateToken(PrincipalDetails principalDetails, long expireTime) {
         Date now = new Date();
         Date expiredDate = new Date(now.getTime() + expireTime);
 
-        PrincipalDetails principalDetails = (PrincipalDetails) authentication.getPrincipal();
         Member member = principalDetails.member();
 
         return Jwts.builder()
@@ -148,7 +148,7 @@ public class TokenProvider {
 
             // RefreshToken이 유효한 경우 새로운 AccessToken 발급
             if (validateToken(refreshToken)){
-                String reissueAccessToken = generateAccessToken(getAuthentication(refreshToken));
+                String reissueAccessToken = generateAccessToken((PrincipalDetails) getAuthentication(refreshToken).getPrincipal());
                 tokenService.updateToken(reissueAccessToken, token);
                 return reissueAccessToken;
             }

--- a/src/main/java/com/groommoa/aether_back_spring/global/auth/service/CustomOauth2UserService.java
+++ b/src/main/java/com/groommoa/aether_back_spring/global/auth/service/CustomOauth2UserService.java
@@ -49,10 +49,10 @@ public class CustomOauth2UserService extends DefaultOAuth2UserService {
         OAuth2UserInfo oAuth2UserInfo = OAuth2UserInfo.of(registrationId, attributes);
 
         // 기존 사용자가 있으면 가져오고, 없으면 저장
-        Member user = getOrSave(oAuth2UserInfo);
+        Member member = getOrSave(oAuth2UserInfo);
 
         // 인증된 사용자 정보를 PrincipalDetails 객체로 반환
-        return new PrincipalDetails(user, attributes, userNameAttributeName);
+        return new PrincipalDetails(member, attributes, userNameAttributeName);
     }
 
     /**
@@ -62,8 +62,8 @@ public class CustomOauth2UserService extends DefaultOAuth2UserService {
      * @return 저장된 User 엔티티 객체
      */
     private Member getOrSave(OAuth2UserInfo oAuth2UserInfo) {
-        Member user = userRepository.findByEmail(oAuth2UserInfo.email())
+        Member member = userRepository.findByEmail(oAuth2UserInfo.email())
                 .orElseGet(oAuth2UserInfo::toEntity);
-        return userRepository.save(user);
+        return userRepository.save(member);
     }
 }

--- a/src/main/java/com/groommoa/aether_back_spring/global/auth/service/TokenService.java
+++ b/src/main/java/com/groommoa/aether_back_spring/global/auth/service/TokenService.java
@@ -23,10 +23,10 @@ public class TokenService {
     /**
      * 특정 사용자의 리프레시 토큰을 삭제합니다.
      *
-     * @param userKey 사용자 고유 키
+     * @param id 사용자 고유 id
      */
-    public void deleteRefreshToken(String userKey) {
-        tokenRepository.deleteById(userKey);
+    public void deleteRefreshToken(String id) {
+        tokenRepository.deleteById(id);
     }
 
     /**

--- a/src/main/java/com/groommoa/aether_back_spring/global/auth/service/TokenService.java
+++ b/src/main/java/com/groommoa/aether_back_spring/global/auth/service/TokenService.java
@@ -32,15 +32,15 @@ public class TokenService {
     /**
      * 리프레시 토큰과 액세스 토큰을 저장하거나 업데이트합니다.
      *
-     * @param userKey      사용자 고유 키
+     * @param id      사용자 id
      * @param refreshToken 새 리프레시 토큰
      * @param accessToken  새로운 액세스 토큰
      */
     @Transactional
-    public void saveOrUpdate(String userKey, String refreshToken, String accessToken) {
+    public void saveOrUpdate(String id, String refreshToken, String accessToken) {
         Token token = tokenRepository.findByAccessToken(accessToken)
                 .map(o -> o.updateRefreshToken(refreshToken))
-                .orElseGet(() -> new Token(userKey, refreshToken, accessToken));
+                .orElseGet(() -> new Token(id, refreshToken, accessToken));
 
         tokenRepository.save(token);
     }


### PR DESCRIPTION
## Description
유저 스키마에서 userKey 필드가 제거됨에 따라 유저 토큰 정보 저장 키를 변경했습니다.

## Changes

- 유저 토큰 키값을 userKey에서 MongoDB에 저장될 때 사용된 objectId로 변경
- 로그아웃 시 objectId를 이용하여 리프레시 토큰을 삭제하도록 변경