### PR TITLE
Feat/#14 토큰 재발급 기능 개선

### DIFF
--- a/src/main/java/com/groommoa/aether_back_spring/global/auth/controller/AuthController.java
+++ b/src/main/java/com/groommoa/aether_back_spring/global/auth/controller/AuthController.java
@@ -77,7 +77,7 @@ public class AuthController {
             newAccessToken = newAccessToken.substring(TokenKey.TOKEN_PREFIX.length());
         } else {
             return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
-                    .body(new CommonResponse(HttpStatus.UNAUTHORIZED, "access token 재발급에 실패했습니다.", null));
+                    .body(new CommonResponse(HttpStatus.UNAUTHORIZED, "만료되지 않은 access token 입니다.", null));
         }
 
         Map<String, Object> result = new HashMap<>();

--- a/src/main/java/com/groommoa/aether_back_spring/global/auth/security/TokenAuthenticationFilter.java
+++ b/src/main/java/com/groommoa/aether_back_spring/global/auth/security/TokenAuthenticationFilter.java
@@ -26,6 +26,7 @@ import static org.springframework.http.HttpHeaders.AUTHORIZATION;
 @Component
 public class TokenAuthenticationFilter extends OncePerRequestFilter {
 
+    private final String reissueUri = "/auth/reissue";
     private final TokenProvider tokenProvider;
 
     /**
@@ -49,8 +50,8 @@ public class TokenAuthenticationFilter extends OncePerRequestFilter {
         if (tokenProvider.validateToken(accessToken)) {
             // 토큰이 유효한 경우 인증 설정
             setAuthentication(accessToken);
-        } else {
-            // 토큰이 만료된 경우 새로운 AccessToken 재발급
+        } else if (request.getRequestURI().equals(reissueUri)) {
+            // 토큰이 만료된 경우 reissue 요청이 들어온 경우에 새로운 AccessToken 재발급
             String reissueAccessToken = tokenProvider.reissueAccessToken(accessToken);
 
             if (StringUtils.hasText(reissueAccessToken)) {

--- a/src/main/java/com/groommoa/aether_back_spring/global/auth/security/TokenProvider.java
+++ b/src/main/java/com/groommoa/aether_back_spring/global/auth/security/TokenProvider.java
@@ -17,8 +17,6 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
-import org.springframework.security.core.userdetails.User;
-import org.springframework.security.oauth2.core.user.OAuth2User;
 import org.springframework.stereotype.Component;
 import org.springframework.util.StringUtils;
 
@@ -54,13 +52,23 @@ public class TokenProvider {
     }
 
     /**
-     * AccessToken 생성
+     * AccessToken 최초 생성
      *
      * @param principalDetails 인증된 유저 정보 객체
      * @return 생성된 AccessToken
      */
     public String generateAccessToken(PrincipalDetails principalDetails) {
         return generateToken(principalDetails, ACCESS_TOKEN_EXPIRE_TIME);
+    }
+
+    /**
+     * AccessToken 재발급
+     *
+     * @param claims 이전 jwt 토큰 claims
+     * @return 생성된 AccessToken
+     */
+    public String generateAccessToken(Claims claims) {
+        return generateToken(claims.getId(), claims, ACCESS_TOKEN_EXPIRE_TIME);
     }
 
     /**
@@ -98,6 +106,29 @@ public class TokenProvider {
                 .compact();
     }
 
+    /**
+     * JWT 토큰 재생성
+     *
+     * @param id 사용자 고유 id
+     * @param claims 이전 JWT 토큰 claims
+     * @param expireTime 토큰 만료 시간
+     * @return 생성된 JWT 토큰
+     */
+    private String generateToken(String id, Claims claims, long expireTime) {
+        Date now = new Date();
+        Date expiredDate = new Date(now.getTime() + expireTime);
+
+        return Jwts.builder()
+                .header().type("JWT")                   // 헤더에 타입 지정
+                .and()
+                .subject(id)                // 멤버 id
+                .claims(claims)            // claim 정보
+                .issuedAt(now)                          // 발급 시간
+                .expiration(expiredDate)                // 만료 시간
+                .signWith(secretKey, Jwts.SIG.HS512)    // 서명 (HMAC SHA512)
+                .compact();
+    }
+
     private Map<String, Object> memberToMap(Member member){
         Map<String, Object> memberMap = new HashMap<>();
 
@@ -118,10 +149,7 @@ public class TokenProvider {
         Claims claims = parseClaims(token);
         List<SimpleGrantedAuthority> authorities = getAuthorities(claims);
 
-        // Spring Security의 User 객체 생성
-        User principal = new User(claims.getSubject(), "", authorities);
-
-        return new UsernamePasswordAuthenticationToken(principal, token, authorities);
+        return new UsernamePasswordAuthenticationToken(claims, token, authorities);
     }
 
     /**
@@ -148,7 +176,8 @@ public class TokenProvider {
 
             // RefreshToken이 유효한 경우 새로운 AccessToken 발급
             if (validateToken(refreshToken)){
-                String reissueAccessToken = generateAccessToken((PrincipalDetails) getAuthentication(refreshToken).getPrincipal());
+                Claims claims = (Claims) getAuthentication(refreshToken).getPrincipal();
+                String reissueAccessToken = generateAccessToken(claims);
                 tokenService.updateToken(reissueAccessToken, token);
                 return reissueAccessToken;
             }

--- a/src/main/java/com/groommoa/aether_back_spring/global/auth/security/TokenProvider.java
+++ b/src/main/java/com/groommoa/aether_back_spring/global/auth/security/TokenProvider.java
@@ -129,6 +129,11 @@ public class TokenProvider {
                 .compact();
     }
 
+    /**
+     * Member 객체의 정보를 Map으로 변환
+     * @param member Member 객체
+     * @return Member 정보를 담은 Map
+     */
     private Map<String, Object> memberToMap(Member member){
         Map<String, Object> memberMap = new HashMap<>();
 


### PR DESCRIPTION
## Descriptions
정해진 엔드포인트로 요청이 들어온 경우에만 액세스 토큰이 재발급되도록 토큰 재발급 기능을 개선했습니다.

## Changes

- "/auth/reissue" 엔드포인트로 요청이 들어온 경우에만 액세스 토큰이 재발급되도록 수정
- 그 외의 엔드포인트로 만료된 액세스 토큰을 이용한 요청이 들어오면 401 Unauthorized 코드만 반환