### PR TITLE
feat: 프론트엔드-백엔드 api 연동

### DIFF
--- a/src/main/java/com/groommoa/aether_back_spring/global/auth/security/TokenProvider.java
+++ b/src/main/java/com/groommoa/aether_back_spring/global/auth/security/TokenProvider.java
@@ -36,7 +36,7 @@ public class TokenProvider {
     @Value("${jwt.key}")
     private String key;
     private SecretKey secretKey;
-    private static final long ACCESS_TOKEN_EXPIRE_TIME = 1000 * 60 * 30L;   // 30분
+    private static final long ACCESS_TOKEN_EXPIRE_TIME = 1000 * 60 * 60L * 24;   // 1일
     private static final long REFRESH_TOKEN_EXPIRE_TIME = 1000 * 60 * 60L * 24 * 7; // 7일
     private static final String KEY_NAME = "name";
     private static final String KEY_EMAIL = "email";


### PR DESCRIPTION
- 액세스 토큰 유효기간 변경: 30분 -> 1일
- api 연동 및 테스트 시에만 한시적 적용