### PR TITLE
Feat/#43: 유저 프로필 정보 조회 api

### DIFF
--- a/src/main/java/com/groommoa/aether_back_spring/domain/user/service/UserService.java
+++ b/src/main/java/com/groommoa/aether_back_spring/domain/user/service/UserService.java
@@ -14,6 +14,11 @@ public class UserService {
 
     private final UserRepository userRepository;
 
+    public Member getUserProfile(String userId){
+        return userRepository.findById(userId)
+                .orElseThrow(() -> new UserException(ErrorCode.USER_NOT_FOUND));
+    }
+
     public Member updateUserProfile(String userId, UpdateUserProfileRequestDto request){
         Member member = userRepository.findById(userId)
                 .orElseThrow(() -> new UserException(ErrorCode.USER_NOT_FOUND));

--- a/src/main/java/com/groommoa/aether_back_spring/global/auth/controller/AuthController.java
+++ b/src/main/java/com/groommoa/aether_back_spring/global/auth/controller/AuthController.java
@@ -3,6 +3,7 @@ package com.groommoa.aether_back_spring.global.auth.controller;
 import com.groommoa.aether_back_spring.domain.user.entity.Member;
 import com.groommoa.aether_back_spring.global.auth.dto.UpdateUserProfileRequestDto;
 import com.groommoa.aether_back_spring.global.auth.dto.UpdateUserProfileResponseDto;
+import com.groommoa.aether_back_spring.global.auth.dto.UserProfileResponseDto;
 import com.groommoa.aether_back_spring.global.auth.service.AuthService;
 import com.groommoa.aether_back_spring.global.auth.service.TokenService;
 import com.groommoa.aether_back_spring.global.common.constants.HttpStatus;
@@ -121,6 +122,20 @@ public class AuthController {
 
         return ResponseEntity.ok(new CommonResponse(
                 HttpStatus.OK, "access token 재발급에 성공했습니다.", result));
+    }
+
+    @GetMapping("/profile")
+    public ResponseEntity<CommonResponse> getUserProfile(
+            @AuthenticationPrincipal Claims claims
+    ) {
+        String userId = claims.getSubject();
+        Member member = authService.getUserProfile(userId);
+        UserProfileResponseDto responseDto = UserProfileResponseDto.from(member);
+
+        CommonResponse response = new CommonResponse(
+                HttpStatus.OK, "현재 로그인된 유저 프로필 조회에 성공했습니다.", DtoUtils.toMap(responseDto));
+
+        return ResponseEntity.ok(response);
     }
 
     @PatchMapping("/profile")

--- a/src/main/java/com/groommoa/aether_back_spring/global/auth/dto/UserProfileResponseDto.java
+++ b/src/main/java/com/groommoa/aether_back_spring/global/auth/dto/UserProfileResponseDto.java
@@ -1,0 +1,25 @@
+package com.groommoa.aether_back_spring.global.auth.dto;
+
+import com.groommoa.aether_back_spring.domain.user.entity.Member;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class UserProfileResponseDto {
+
+    private final String username;
+    private final String rank;
+    private final String userId;
+    private final String email;
+
+    public static UserProfileResponseDto from(Member member) {
+        return UserProfileResponseDto.builder()
+                .username(member.getName())
+                .rank(String.valueOf(member.getRank()))
+                .userId(member.getId())
+                .email(member.getEmail())
+                .build();
+    }
+
+}

--- a/src/main/java/com/groommoa/aether_back_spring/global/auth/service/AuthService.java
+++ b/src/main/java/com/groommoa/aether_back_spring/global/auth/service/AuthService.java
@@ -12,6 +12,10 @@ public class AuthService {
 
     private final UserService userService;
 
+    public Member getUserProfile(String userId){
+        return userService.getUserProfile(userId);
+    }
+
     public Member updateUserProfile(String userId, UpdateUserProfileRequestDto request){
         return userService.updateUserProfile(userId, request);
     }

--- a/src/main/java/com/groommoa/aether_back_spring/global/common/handler/GlobalExceptionHandler.java
+++ b/src/main/java/com/groommoa/aether_back_spring/global/common/handler/GlobalExceptionHandler.java
@@ -3,7 +3,9 @@ package com.groommoa.aether_back_spring.global.common.handler;
 import com.fasterxml.jackson.core.JsonParseException;
 import com.fasterxml.jackson.databind.exc.InvalidFormatException;
 import com.fasterxml.jackson.databind.exc.MismatchedInputException;
+import com.groommoa.aether_back_spring.domain.user.exception.UserException;
 import com.groommoa.aether_back_spring.global.common.constants.HttpStatus;
+import com.groommoa.aether_back_spring.global.common.exception.ErrorCode;
 import com.groommoa.aether_back_spring.global.common.response.ErrorResponse;
 import com.mongodb.MongoException;
 import org.apache.commons.lang.exception.ExceptionUtils;
@@ -99,6 +101,14 @@ public class GlobalExceptionHandler {
                 HttpStatus.BAD_REQUEST, "유효하지 않은 입력값입니다.", details
         );
         return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(response);
+    }
+
+    @ExceptionHandler(UserException.class)
+    public ResponseEntity<ErrorResponse> handleUserException(UserException ex) {
+        ErrorCode errorCode = ex.getErrorCode();
+        ErrorResponse response = new ErrorResponse(
+                errorCode.getHttpStatus().value(), errorCode.getMessage(), null);
+        return ResponseEntity.status(ex.getErrorCode().getHttpStatus()).body(response);
     }
 
 


### PR DESCRIPTION
## 1. 유저 프로필 정보 조회 api 추가

### [GET] /auth/profile

현재 로그인된 유저의 프로필 정보를 조회합니다.

#### Headers

| 헤더명         | 필수 | 설명                                  |
|----------------|------|----------------------------------------|
| `Content-Type` | ✅   | `application/json`                    |
| `Authorization`| ✅   | `Bearer {JWT_TOKEN}` |

#### Request Body

없음 (None)

#### Response Body

| 필드명           | 타입                | 설명                                                         |
|------------------|---------------------|--------------------------------------------------------------|
| `username`        | `String`            | 사용자 이름  |
| `rank`         | `Rank (Enum)` | 사용자 직급 |
| `userId`       | `ObjectId (String)` | 사용자의 User ObjectId  |
| `email`     | `String`            | 사용자 이메일 |

#### Response Body - Example

**200 - OK**

```
{
    "code": 200,
    "message": "현재 로그인된 유저 프로필 조회에 성공했습니다.",
    "result": {
        "username": "홍길동",
        "rank": "Intern",
        "userId": "68308473318f5014ad2fcfeb",
        "email": "abc123@gmail.com"
    }
}
```

**404 - Not Found**

```
{
    "code": 404,
    "message": "유저를 찾을 수 없습니다.",
    "details": null
}
```

## Change Logs

- 2025-05-23: 유저 프로필 정보 조회 API 최초 작성